### PR TITLE
Feature/entity relations

### DIFF
--- a/core/src/main/java/com/dam/commune/Property/Property.java
+++ b/core/src/main/java/com/dam/commune/Property/Property.java
@@ -1,5 +1,8 @@
 package com.dam.commune.property;
 
+import com.dam.commune.community.Community;
+import com.dam.commune.owner.Owner;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -7,6 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,10 +32,12 @@ public abstract class Property {
     @Column(name= "square_meters", nullable = false)
     private Double squareMeters;
 
-    // La relación con Community 
-    // @ManyToOne
-    // private Community community;
+  
+    @ManyToOne
+    @JoinColumn(name = "community_id")
+    private Community community;
 
-    // @ManyToOne
-    // private Owner owner;
+     @ManyToOne
+     @JoinColumn(name = "owner_id")
+     private Owner owner;
 }

--- a/core/src/main/java/com/dam/commune/bankAccount/BankAccount.java
+++ b/core/src/main/java/com/dam/commune/bankAccount/BankAccount.java
@@ -2,6 +2,9 @@ package com.dam.commune.bankAccount;
 
 import java.math.BigDecimal;
 
+import com.dam.commune.community.Community;
+import com.dam.commune.owner.Owner;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,5 +32,12 @@ public class BankAccount {
 
     @Column(nullable = false)
     private BigDecimal balance;
+
+    @OneToOne(mappedBy = "bankAccount")
+    private Community community;
+
+    @ManyToOne
+    @JoinColumn(name = "owner_id")
+    private Owner owner;
 
 }

--- a/core/src/main/java/com/dam/commune/community/Community.java
+++ b/core/src/main/java/com/dam/commune/community/Community.java
@@ -1,5 +1,10 @@
 package com.dam.commune.community;
 
+import java.util.List;
+
+import com.dam.commune.bankAccount.BankAccount;
+import com.dam.commune.property.Property;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,9 +33,17 @@ public class Community {
     private String postalCode;
 
     private boolean elevator;
+    
 
     @Column(name = "reduced_mobility_access")
     private boolean reducedMobilityAccess;
+
+    @OneToOne
+    @JoinColumn(name = "bank_account_id")
+    private BankAccount bankAccount;
+
+    @OneToMany(mappedBy = "community", cascade = CascadeType.ALL)
+    private List<Property> properties;
 
  
 }

--- a/core/src/main/java/com/dam/commune/owner/Owner.java
+++ b/core/src/main/java/com/dam/commune/owner/Owner.java
@@ -2,11 +2,16 @@ package com.dam.commune.owner;
 
 
 import java.time.LocalDate;
+import java.util.List;
+
+import com.dam.commune.bankAccount.BankAccount;
+import com.dam.commune.property.Property;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,7 +40,10 @@ public class Owner {
     @Column(nullable = false)
     LocalDate birthDate;
 
-    //@OneToMany(mappedBy = "owner")
-    //private List<Property> properties;
+    @OneToMany(mappedBy = "owner")
+    private List<Property> properties;
+
+    @OneToMany(mappedBy = "owner")
+    private List<BankAccount> bankAccounts;
 
 }


### PR DESCRIPTION
This pull request introduces relationships between the `Property`, `BankAccount`, `Community`, and `Owner` entities in the codebase. It adds annotations and fields to establish `@ManyToOne`, `@OneToOne`, and `@OneToMany` relationships, enabling better data modeling and interaction between these entities.

### Entity Relationship Enhancements:

* **`Property` Entity**:
  - Added `@ManyToOne` relationships with `Community` and `Owner` entities, along with corresponding `@JoinColumn` annotations to map the foreign keys (`community_id` and `owner_id`).

* **`BankAccount` Entity**:
  - Added a `@OneToOne` relationship with the `Community` entity, mapped by the `bankAccount` field in `Community`.
  - Added a `@ManyToOne` relationship with the `Owner` entity, with a `@JoinColumn` for the `owner_id` foreign key.

* **`Community` Entity**:
  - Added a `@OneToOne` relationship with the `BankAccount` entity, with a `@JoinColumn` for the `bank_account_id` foreign key.
  - Added a `@OneToMany` relationship with the `Property` entity, mapped by the `community` field in `Property`.

* **`Owner` Entity**:
  - Added a `@OneToMany` relationship with the `Property` entity, mapped by the `owner` field in `Property`.
  - Added a `@OneToMany` relationship with the `BankAccount` entity, mapped by the `owner` field in `BankAccount`.