### PR TITLE
feat: Add email sending capability to owner invoices in the frontend

### DIFF
--- a/frontend/src/app/models/InvoiceOwner.ts
+++ b/frontend/src/app/models/InvoiceOwner.ts
@@ -9,4 +9,5 @@ export interface InvoiceOwner {
   // properties?: PropertyDTO[];
   coefficient: number;
   communityName: string;
+  email: string;
 }

--- a/frontend/src/app/pages/invoices/owner/owner.component.html
+++ b/frontend/src/app/pages/invoices/owner/owner.component.html
@@ -29,6 +29,9 @@
           <button class="btn btn-outline-primary btn-sm" (click)="downloadInvoice(invoice.id)">
             Descargar PDF
           </button>
+          <button class="btn btn-outline-success btn-sm" (click)="sendByEmail(invoice.id,invoice.email)">
+            Enviar por email
+          </button>
         </td>
       </tr>
     </tbody>

--- a/frontend/src/app/pages/invoices/owner/owner.component.ts
+++ b/frontend/src/app/pages/invoices/owner/owner.component.ts
@@ -12,6 +12,7 @@ import { InvoiceService } from '../../../service/invoice-service.service';
 })
 export class OwnerInvoicesComponent implements OnInit {
 
+
    ownerId!: number;
   invoices: InvoiceOwner[] = []; 
 
@@ -54,6 +55,45 @@ export class OwnerInvoicesComponent implements OnInit {
       }
     });
   }
+
+  sendByEmail(invoiceId: number, email: string) {
+  if (!email) {
+    alert('No se encuentra el email del destinatario.');
+    return;
+  }
+
+  this.invoiceService.sendByEmail(invoiceId, email)
+    .subscribe({
+      next: () => {
+        alert('Factura enviada por email correctamente.');
+        // Aquí podrías usar un toast o resetear algún estado si lo necesitas
+      },
+      error: err => {
+        // Procesa el error para mostrar el mensaje más informativo posible
+        let errorMsg = 'Desconocido';
+
+        // Si es texto plano (lo habitual con responseType: 'text')
+        if (typeof err.error === 'string') {
+          errorMsg = err.error;
+        }
+        // Si viene como objeto con un campo 'message'
+        else if (err.error && typeof err.error === 'object' && err.error.message) {
+          errorMsg = err.error.message;
+        }
+        // Si hay un mensaje general
+        else if (err.message) {
+          errorMsg = err.message;
+        }
+        // Si es otro tipo de objeto/error
+        else if (err.error) {
+          errorMsg = JSON.stringify(err.error);
+        }
+
+        alert('Error al enviar la factura: ' + errorMsg);
+      }
+    });
+}
+
 
 
 

--- a/frontend/src/app/service/invoice-service.service.ts
+++ b/frontend/src/app/service/invoice-service.service.ts
@@ -28,6 +28,12 @@ export class InvoiceService {
   downloadOwnerInvoice(invoiceId: number): Observable<Blob> {
   return this.http.get(`${this.apiUrl}/invoices/owner-invoice/${invoiceId}/pdf`, { responseType: 'blob' });
   }
+
+  sendByEmail(invoiceId: number, email: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/invoices/emails/owner-invoice/${invoiceId}/send`,null,{ params: {email}});
+
+}
+
  
 
 

--- a/microservices/pdfgenerator/models/invoice_owner.py
+++ b/microservices/pdfgenerator/models/invoice_owner.py
@@ -13,3 +13,4 @@ class OwnerInvoice:
     coefficient: float
     communityName: str
     properties: Optional[list] = None  # TODO
+    email: Optional[str] = None


### PR DESCRIPTION
### Description
This pull request adds frontend support for sending owner invoices via email, including UI and model enhancements.

#### Key updates:
- **Extended `InvoiceOwner` model:**  
  - Added an `email` property to the TypeScript interface for storing the owner's email address.  
  - *(File: `frontend/src/app/models/InvoiceOwner.ts`)*
- **"Send by Email" button in UI:**  
  - Added a button to the owner invoices list that allows users to send invoices via email.  
  - *(File: `frontend/src/app/pages/invoices/owner/owner.component.html`)*
- **Implemented `sendByEmail` method:**  
  - Created a method in the `OwnerInvoicesComponent` to handle the email sending process, including error handling and user notifications.  
  - *(File: `frontend/src/app/pages/invoices/owner/owner.component.ts`)*
- **Integrated with `InvoiceService`:**  
  - Added a service method to trigger the backend API call for email sending.  
  - *(File: `frontend/src/app/service/invoice-service.service.ts`)*
